### PR TITLE
Fix outdated github link

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -26,7 +26,7 @@
         Choo Choo! This is an example of an NGINX static site running on
         Railway.
         <a
-          href="https://github.com/railwayapp/starters/tree/master/examples/nginx"
+          href="https://github.com/railwayapp-templates/nginx"
           >View source</a
         >.
       </p>


### PR DESCRIPTION
The github link on the source appears empty, and this seems like the correct place to link to now.